### PR TITLE
add missing metadata field repository/url needed to be imported from …

### DIFF
--- a/package.json
+++ b/package.json
@@ -101,5 +101,9 @@
     "videojs-generator-verify": "~1.2.0",
     "videojs-languages": "^2.0.0",
     "videojs-standard": "^8.0.3"
+  },
+  "repository": {
+      "type": "git",
+      "url": "https://github.com/samueleastdev/videojs-timecodes.git"
   }
 }


### PR DESCRIPTION
…webjars.org

This is the error message when we try to import the project to webjars.org:
```
Starting Deploy
[[37minfo[0m] p.a.h.HttpErrorHandlerExceptions - Registering exception handler: guice-provision-exception-handler

[[37minfo[0m] o.a.p.a.CoordinatedShutdown - Running CoordinatedShutdown with reason [ApplicationStoppedReason]

The metadata was missing a required field: /repository/url
```